### PR TITLE
fixing quoting error in help

### DIFF
--- a/bin/parserver
+++ b/bin/parserver
@@ -36,7 +36,7 @@ ARGV.options do |opts|
   opts.separator ""
 
   opts.on("-H", "--host=host", String,
-          "Specifies host as "127.0.0.1", "localhost" etc.",
+          "Specifies host as '127.0.0.1', 'localhost' etc.",
           "Default: #{DEFAULT_HOST}") { |host| options[:host] = host }
 
   opts.separator ""


### PR DESCRIPTION
parserver seems to have a small issue in the help section causing the ruby to complain about missing quotes. This pull fixes the problem.